### PR TITLE
test case for string encoding

### DIFF
--- a/test/fixtures/example.yaml.fixture
+++ b/test/fixtures/example.yaml.fixture
@@ -31,11 +31,12 @@
     TestEncoding:
       to: $NameReg
       fun_name: some_method
-      sig: iii
+      sig: iiis
       data:
         - $Subcurrency
         - 42
         - "\x01\x00"
+        - \x01\x00
       gas: 10000
       gas_price: 10000000000000
       value: 0

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -271,7 +271,7 @@ def test_load_yaml():
             'transact': {
                 'TestEncoding': {
                     'fun_name': 'some_method',
-                    'sig': 'iii',
+                    'sig': 'iiis',
                     'gas': 10000,
                     'gas_price': 10000000000000,
                     'to': '$NameReg',
@@ -279,7 +279,8 @@ def test_load_yaml():
                     'data': [
                         '$Subcurrency',
                         42,
-                        '\x01\x00'],
+                        '\x01\x00',
+                        '\\x01\\x00'],
                     'wait': False
                 }
             }


### PR DESCRIPTION
added a test.

there's one more test that would be interesting and it is to add another string, so that
fixture has: ""\x01\x00" and make the sig "iiiss".  but I'm not sure currently what's happening to add it.