### PR TITLE
Support remaining params for eth_call

### DIFF
--- a/pyepm/api.py
+++ b/pyepm/api.py
@@ -213,12 +213,13 @@ class Api(object):
         if fun_name is not None:
             data = abi_data(fun_name, sig, data)
 
+        if from_ is None:
+            from_ = self.address
+
         if gas is None:
             gas = self.gas
         if gas_price is None:
             gas_price = self.gas_price
-        if from_ is None:
-            from_ = self.address
         if not self.fixed_price:
             net_price = self.gasprice()
             logger.debug("Gas price: %s" % net_price)
@@ -236,7 +237,7 @@ class Api(object):
             'value': hex(value).rstrip('L')}]
         return self._rpc_post('eth_sendTransaction', params)
 
-    def call(self, dest, fun_name, sig='', data=None, from_=None, defaultBlock='latest'):
+    def call(self, dest, fun_name, sig='', data=None, gas=None, gas_price=None, value=0, from_=None, defaultBlock='latest'):
         if not dest.startswith('0x'):
             dest = '0x' + dest
 
@@ -246,10 +247,25 @@ class Api(object):
         if from_ is None:
             from_ = self.address
 
+        if gas is None:
+            gas = self.gas
+        if gas_price is None:
+            gas_price = self.gas_price
+        if not self.fixed_price:
+            net_price = self.gasprice()
+            logger.debug("Gas price: %s" % net_price)
+            if net_price is None:
+                gas_price = self.gas_price
+            else:
+                gas_price = net_price
+
         params = [{
             'from': from_,
             'to': dest,
-            'data': data}, defaultBlock]
+            'data': data,
+            'gas': hex(gas).rstrip('L'),
+            'gasPrice': hex(gas_price).rstrip('L'),
+            'value': hex(value).rstrip('L')}, defaultBlock]
         r = self._rpc_post('eth_call', params)
         if r is not None:
             return decode_datalist(r[2:].decode('hex'))

--- a/pyepm/deploy.py
+++ b/pyepm/deploy.py
@@ -119,7 +119,7 @@ class Deploy(object):
                         if key == 'transact':
                             self.transact(to, from_, fun_name, sig, data, gas, gas_price, value, wait)
                         elif key == 'call':
-                            self.call(to, from_, fun_name, sig, data)
+                            self.call(to, from_, fun_name, sig, data, gas, gas_price, value)
 
     def compile_solidity(self, contract, contract_names=[]):
         if not spawn.find_executable("solc"):
@@ -193,10 +193,10 @@ class Deploy(object):
         if wait:
             instance.wait_for_next_block(from_block=from_block, verbose=(True if self.config.get('misc', 'verbosity') > 1 else False))
 
-    def call(self, to, from_, fun_name, sig, data):
+    def call(self, to, from_, fun_name, sig, data, gas, gas_price, value):
         instance = api.Api(self.config)
 
-        result = instance.call(to, fun_name=fun_name, sig=sig, data=data)
+        result = instance.call(to, fun_name=fun_name, sig=sig, data=data, gas=gas, gas_price=gas_price, value=value)
         logger.info("      Result: %s" % result)
 
         return result

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -22,6 +22,7 @@ def test_api_exception_status_code(mocker):
 
 def mock_rpc(mocker, rpc_fun, rpc_args, json_result, rpc_method, rpc_params):
     instance = api.Api(config)
+    instance.fixed_price = True
 
     mocker.patch('requests.post', return_value=mock_json_response(result=json_result))
     mock_rpc_post = mocker.patch.object(instance, '_rpc_post', side_effect=instance._rpc_post)
@@ -154,15 +155,18 @@ def test_call_multiply(mocker):
     fun_name = 'multiply'
     sig = 'i'
     data = [3]
+    value = 0
+    gas = 100000
+    gas_price = 10000000000000
     data_abi = '0x1df4f1440000000000000000000000000000000000000000000000000000000000000003'
     json_result = '0x0000000000000000000000000000000000000000000000000000000000000015'
-    rpc_params = [{'gas': hex(100000),
+    rpc_params = [{'gas': hex(gas),
                    'from': COW_ADDRESS,
                    'to': address,
                    'data': data_abi,
-                   'value': hex(0),
-                   'gasPrice': hex(10000000000000)}, 'latest']
-    assert mock_rpc(mocker, 'call', [address, fun_name, sig, data], json_result=json_result,
+                   'value': hex(value),
+                   'gasPrice': hex(gas_price)}, 'latest']
+    assert mock_rpc(mocker, 'call', [address, fun_name, sig, data, gas, gas_price, value], json_result=json_result,
                     rpc_method='eth_call', rpc_params=rpc_params) == [21]
 
 def test_call_returning_array(mocker):
@@ -175,11 +179,8 @@ def test_call_returning_array(mocker):
                   '0000000000000000000000000000000000000000000000000000000000000002' +\
                   '0000000000000000000000000000000000000000000000000000000000000001' +\
                   '0000000000000000000000000000000000000000000000000000000000000000'
-    rpc_params = [{'gas': hex(100000),
-                   'from': COW_ADDRESS,
+    rpc_params = [{'from': COW_ADDRESS,
                    'to': address,
-                   'data': data_abi,
-                   'value': hex(0),
-                   'gasPrice': hex(10000000000000)}, 'latest']
+                   'data': data_abi}, 'latest']
     assert mock_rpc(mocker, 'call', [address, fun_name, sig, data], json_result=json_result,
                     rpc_method='eth_call', rpc_params=rpc_params) == [3, 2, 1, 0]  # with length prefix of 3

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -156,9 +156,12 @@ def test_call_multiply(mocker):
     data = [3]
     data_abi = '0x1df4f1440000000000000000000000000000000000000000000000000000000000000003'
     json_result = '0x0000000000000000000000000000000000000000000000000000000000000015'
-    rpc_params = [{'from': COW_ADDRESS,
+    rpc_params = [{'gas': hex(100000),
+                   'from': COW_ADDRESS,
                    'to': address,
-                   'data': data_abi}, 'latest']
+                   'data': data_abi,
+                   'value': hex(0),
+                   'gasPrice': hex(10000000000000)}, 'latest']
     assert mock_rpc(mocker, 'call', [address, fun_name, sig, data], json_result=json_result,
                     rpc_method='eth_call', rpc_params=rpc_params) == [21]
 
@@ -172,8 +175,11 @@ def test_call_returning_array(mocker):
                   '0000000000000000000000000000000000000000000000000000000000000002' +\
                   '0000000000000000000000000000000000000000000000000000000000000001' +\
                   '0000000000000000000000000000000000000000000000000000000000000000'
-    rpc_params = [{'from': COW_ADDRESS,
+    rpc_params = [{'gas': hex(100000),
+                   'from': COW_ADDRESS,
                    'to': address,
-                   'data': data_abi}, 'latest']
+                   'data': data_abi,
+                   'value': hex(0),
+                   'gasPrice': hex(10000000000000)}, 'latest']
     assert mock_rpc(mocker, 'call', [address, fun_name, sig, data], json_result=json_result,
                     rpc_method='eth_call', rpc_params=rpc_params) == [3, 2, 1, 0]  # with length prefix of 3

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -83,8 +83,7 @@ def test_create(mocker):
                    'data': '0xdeadbeef',
                    'from': COW_ADDRESS,
                    'value': hex(0),
-                   'gasPrice': '0x6489ecbe173ac43dadb9f4f098c3e663e8438dd7'}]  # bad mocking...
-    # 'gasPrice': hex(10000000000000)}]
+                   'gasPrice': hex(10000000000000)}]
     assert mock_rpc(mocker, 'create', [code], json_result=address,
                     rpc_method='eth_sendTransaction', rpc_params=rpc_params) == address
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -178,8 +178,11 @@ def test_call_returning_array(mocker):
                   '0000000000000000000000000000000000000000000000000000000000000002' +\
                   '0000000000000000000000000000000000000000000000000000000000000001' +\
                   '0000000000000000000000000000000000000000000000000000000000000000'
-    rpc_params = [{'from': COW_ADDRESS,
+    rpc_params = [{'gas': hex(100000),
+                   'from': COW_ADDRESS,
                    'to': address,
-                   'data': data_abi}, 'latest']
+                   'data': data_abi,
+                   'value': hex(0),
+                   'gasPrice': hex(10000000000000)}, 'latest']
     assert mock_rpc(mocker, 'call', [address, fun_name, sig, data], json_result=json_result,
                     rpc_method='eth_call', rpc_params=rpc_params) == [3, 2, 1, 0]  # with length prefix of 3


### PR DESCRIPTION
https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_call

This PR started as a way to add support for "value", but the opportunity was taken to also add the others (gas and gas_price).  Use cases could be constructed for their usefulness, and here is one for "value": Take a contract that only performs an action if it receives ether from the sender; by supporting "value" a pyepm "call" could be used instead of "transact" to test this behavior.

This PR also fixed the "bad mocking" in test_create by setting fixed_price in the mocker.

Some further DRYing and refactoring could be done.