### PR TITLE
pyethereum doesn't accept null for params

### DIFF
--- a/pyepm/api.py
+++ b/pyepm/api.py
@@ -64,6 +64,9 @@ class Api(object):
         self.fixed_price = config.getboolean("deploy", "fixed_price")
 
     def _rpc_post(self, method, params):
+        if params is None:
+            params = []
+
         payload = {
             "jsonrpc": "2.0",
             "id": str(uuid4()),


### PR DESCRIPTION
"workaround" for https://github.com/ethereum/pyethereum/issues/265

ran py.test, as well as tested pyepm with consensys/testrpc
